### PR TITLE
feat: mute & unmute

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Elk: [https://elk.zone/misstodon.liuli.lol/@gizmo_ds](https://elk.zone/misstodon
   - [x] `POST` /api/v1/accounts/:user_id/follow
   - [x] `POST` /api/v1/accounts/:user_id/unfollow
   - [x] `GET` /api/v1/follow_requests
-  - [ ] `POST` /api/v1/accounts/:user_id/mute
-  - [ ] `POST` /api/v1/accounts/:user_id/unmute
+  - [x] `POST` /api/v1/accounts/:user_id/mute
+  - [x] `POST` /api/v1/accounts/:user_id/unmute
   - [x] `GET` /api/v1/bookmarks
   - [ ] `GET` /api/v1/favourites
 - [ ] Statuses

--- a/proxy/misskey/accounts.go
+++ b/proxy/misskey/accounts.go
@@ -384,6 +384,37 @@ func AccountUnfollow(server, token string, accountID string) error {
 	return nil
 }
 
+func AccountMute(server, token string, accountID string, expiresAt int64) error {
+	data := utils.Map{"i": token, "userId": accountID}
+	if expiresAt > 0 {
+		data["expiresAt"] = expiresAt
+	}
+	resp, err := client.R().
+		SetBody(data).
+		Post(utils.JoinURL(server, "/api/mute/create"))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err = isucceed(resp, http.StatusOK); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func AccountUnmute(server, token string, accountID string) error {
+	data := utils.Map{"i": token, "userId": accountID}
+	resp, err := client.R().
+		SetBody(data).
+		Post(utils.JoinURL(server, "/api/mute/delete"))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err = isucceed(resp, http.StatusOK); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
 func AccountsGet(server, token, accountID string) (models.Account, error) {
 	var info models.Account
 	var serverInfo models.MkUser


### PR DESCRIPTION
I couldn't test this (/ try it out in a real instance) either, please give it a try before merging!

- Mastodon accepts a `duration` param in seconds https://docs.joinmastodon.org/methods/accounts/#mute
- Misskey accepts an `expiresAt` param in unixms https://misskey.io/api-doc#tag/account/operation/mute/create
